### PR TITLE
Various improvements

### DIFF
--- a/src/components/MapEmbed/MapEmbed.js
+++ b/src/components/MapEmbed/MapEmbed.js
@@ -5,6 +5,10 @@ import { useGoogleScript } from '../../context/GoogleScriptContext';
 const mapContainerStyle = { width: '100%', height: '100%' };
 const mapOptions = { streetViewControl: false, mapTypeControl: false, fullscreenControl: false };
 
+// These values were chosen to be center the US
+const initialMapZoom = 4;
+const initialMapCenter = { lat: 40, lng: -100 };
+
 function createGooglePlace(waypoint) {
   return { placeId: waypoint.place_id };
 }
@@ -56,6 +60,8 @@ export default function MapEmbed({ waypoints, onRouteChanged }) {
   if (!isGoogleScriptLoaded) return <></>;
   return (
     <GoogleMap
+      zoom={initialMapZoom}
+      center={initialMapCenter}
       mapContainerStyle={mapContainerStyle}
       options={mapOptions}
       onLoad={map => mapRef.current = map}

--- a/src/components/MapEmbed/MapEmbed.js
+++ b/src/components/MapEmbed/MapEmbed.js
@@ -1,60 +1,64 @@
-import { SkeletonText } from '@chakra-ui/react';
-import { DirectionsService, GoogleMap } from '@react-google-maps/api';
-import { useRef, useState } from 'react';
+import { GoogleMap } from '@react-google-maps/api';
+import { useEffect, useRef } from 'react';
 import { useGoogleScript } from '../../context/GoogleScriptContext';
 
 const mapContainerStyle = { width: '100%', height: '100%' };
 const mapOptions = { streetViewControl: false, mapTypeControl: false, fullscreenControl: false };
 
-export default function MapEmbed({ waypoints, setLegs }) {
-  const [shouldLoadDirections, setShouldLoadDirections] = useState(true);
-  const [prevWaypoints, setPrevWaypoints] = useState(waypoints);
-  const { isLoaded } = useGoogleScript();
+function createGooglePlace(waypoint) {
+  return { placeId: waypoint.place_id };
+}
+
+export default function MapEmbed({ waypoints, onRouteChanged }) {
+  const { isLoaded: isGoogleScriptLoaded } = useGoogleScript();
   const mapRef = useRef();
   const directionsRendererRef = useRef();
 
-  if (waypoints !== prevWaypoints) {
-    setPrevWaypoints(waypoints);
-    setShouldLoadDirections(true);
-  }
+  useEffect(() => {
+    if (isGoogleScriptLoaded && waypoints && waypoints.length >= 2) {
+      // NOTE: we are assuming the waypoints are in sorted order.
+      const origin = createGooglePlace(waypoints.at(0));
+      const destination = createGooglePlace(waypoints.at(-1));
+      const googleWaypoints = waypoints.slice(1, -1).map((waypoint) => ({ location: createGooglePlace(waypoint) }));
 
-  const directionsResultCallback = (response) => {
-    if (response && response.status === 'OK') {
-      setShouldLoadDirections(false);
+      const directionRequest = {
+        origin,
+        destination,
+        waypoints: googleWaypoints,
+        travelMode: 'DRIVING'
+      };
 
-      setLegs(response.routes[0].legs);
-
-      // Unbind previous direction renderer from map so it doesn't continue displaying an old route.
-      directionsRendererRef.current?.setMap(null);
-
-      // Create a new directions renderer with the new route
       // eslint-disable-next-line no-undef
-      directionsRendererRef.current = new google.maps.DirectionsRenderer({
-        directions: response,
-        map: mapRef.current
-      });
-    }
-  };
+      const directionsService = new google.maps.DirectionsService();
+      directionsService.route(directionRequest)
+        .then(directionsResult => {
+          if (directionsResult.status === 'OK') {
+            onRouteChanged(directionsResult.routes[0]);
 
-  if (!isLoaded) return <SkeletonText />;
+            // Unbind previous direction renderer from map so it doesn't continue displaying an old route.
+            directionsRendererRef.current?.setMap(null);
+
+            // Create a new directions renderer with the new route
+            // eslint-disable-next-line no-undef
+            directionsRendererRef.current = new google.maps.DirectionsRenderer({
+              directions: directionsResult,
+              map: mapRef.current
+            });
+          }
+        })
+        .catch(error => {
+          // eslint-disable-next-line no-console
+          console.error('Error while loading directions', error);
+        });
+    }
+  }, [isGoogleScriptLoaded, waypoints, onRouteChanged]);
+
+  if (!isGoogleScriptLoaded) return <></>;
   return (
     <GoogleMap
       mapContainerStyle={mapContainerStyle}
       options={mapOptions}
       onLoad={map => mapRef.current = map}
-    >
-      {waypoints && waypoints.length >= 2 && shouldLoadDirections && (
-        <DirectionsService
-          callback={directionsResultCallback}
-          options={{
-            // NOTE: we are assuming the waypoints are in sorted order.
-            origin: { placeId: waypoints[0].place_id },
-            destination: { placeId: waypoints[waypoints.length - 1].place_id },
-            waypoints: waypoints.slice(1, -1).map((waypoint) => ({ location: { placeId: waypoint.place_id } })),
-            travelMode: 'DRIVING',
-          }}
-        />
-      )}
-    </GoogleMap>
+    />
   );
 }

--- a/src/components/PlaceInput/PlaceInput.js
+++ b/src/components/PlaceInput/PlaceInput.js
@@ -1,20 +1,30 @@
 import { Input } from '@chakra-ui/react';
 import { Autocomplete } from '@react-google-maps/api';
-import { useRef, useState } from 'react';
+import { forwardRef, useRef, useState } from 'react';
 import { useGoogleScript } from '../../context/GoogleScriptContext';
 
 const minimumFields = ['place_id', 'name'];
 
-export default function PlaceInput({
+export default forwardRef(function PlaceInput({
+  onChange = () => {},
   placeholder,
-  fields = [],
-  onChange = () => {}
-}) {
+  fields = []
+}, ref) {
   const { isLoaded: isGoogleScriptLoaded } = useGoogleScript();
   const autocompleteRef = useRef();
 
   const [inputValue, setInputValue] = useState('');
   const [place, setPlace] = useState();
+
+  if (ref) {
+    ref.current = {
+      clear() {
+        setInputValue('');
+        setPlace();
+        onChange();
+      }
+    };
+  }
 
   const onPlaceChanged = () => {
     const newPlace = autocompleteRef.current.getPlace();
@@ -45,4 +55,4 @@ export default function PlaceInput({
       />
     </Autocomplete>
   );
-}
+});

--- a/src/components/PlaceInput/PlaceInput.js
+++ b/src/components/PlaceInput/PlaceInput.js
@@ -1,0 +1,48 @@
+import { Input } from '@chakra-ui/react';
+import { Autocomplete } from '@react-google-maps/api';
+import { useRef, useState } from 'react';
+import { useGoogleScript } from '../../context/GoogleScriptContext';
+
+const minimumFields = ['place_id', 'name'];
+
+export default function PlaceInput({
+  placeholder,
+  fields = [],
+  onChange = () => {}
+}) {
+  const { isLoaded: isGoogleScriptLoaded } = useGoogleScript();
+  const autocompleteRef = useRef();
+
+  const [inputValue, setInputValue] = useState('');
+  const [place, setPlace] = useState();
+
+  const onPlaceChanged = () => {
+    const newPlace = autocompleteRef.current.getPlace();
+    setPlace(newPlace);
+    setInputValue(newPlace.name);
+    onChange(newPlace);
+  };
+
+  const onInputChanged = (e) => {
+    setInputValue(e.target.value);
+    if (place) {
+      setPlace();
+      onChange();
+    }
+  };
+
+  if (!isGoogleScriptLoaded) return <div></div>;
+  return (
+    <Autocomplete
+      fields={Array.from(new Set([...minimumFields, ...fields]))}
+      onLoad={(autocomplete => autocompleteRef.current = autocomplete)}
+      onPlaceChanged={onPlaceChanged}
+    >
+      <Input
+        placeholder={placeholder}
+        value={inputValue}
+        onChange={onInputChanged}
+      />
+    </Autocomplete>
+  );
+}

--- a/src/components/SidePanel/SidePanel.js
+++ b/src/components/SidePanel/SidePanel.js
@@ -68,7 +68,7 @@ export default function SidePanel({ trip, setTrip, legs }) {
         borderBottom="3px solid #006D77"
       >{trip.title}</Heading>
       <Flex flexGrow="1" overflow="scroll" width="100%" direction="column" align="center">
-        {trip.waypoints && legs && <WaypointList waypoints={trip.waypoints} trip={trip} setTrip={setTrip} legs={legs} />}
+        {legs && <WaypointList waypoints={trip.waypoints} trip={trip} setTrip={setTrip} legs={legs} />}
       </Flex>
       <Flex align="center" gap="10px" marginTop="36px">
         <FormControl isRequired>

--- a/src/components/SidePanel/SidePanel.js
+++ b/src/components/SidePanel/SidePanel.js
@@ -68,7 +68,7 @@ export default function SidePanel({ trip, setTrip, legs }) {
         borderBottom="3px solid #006D77"
       >{trip.title}</Heading>
       <Flex flexGrow="1" overflow="scroll" width="100%" direction="column" align="center">
-        {legs && <WaypointList waypoints={trip.waypoints} trip={trip} setTrip={setTrip} legs={legs} />}
+        {legs && <WaypointList trip={trip} setTrip={setTrip} legs={legs} />}
       </Flex>
       <Flex align="center" gap="10px" marginTop="36px">
         <FormControl isRequired>

--- a/src/components/TripPage/TripPage.js
+++ b/src/components/TripPage/TripPage.js
@@ -8,7 +8,7 @@ import { Box } from '@chakra-ui/react';
 
 export default function TripPage() {
   const { id } = useParams();
-  const { trip, setTrip } = useTrip(id);
+  const { trip, setTrip, loading: isTripLoading } = useTrip(id);
   const [legs, setLegs] = useState(null);
 
   const onRouteChanged = useCallback((route) => setLegs(route.legs), [setLegs]);
@@ -17,8 +17,8 @@ export default function TripPage() {
     <>
       <Header />
       <Box pos="relative">
-        <MapEmbed waypoints={trip.waypoints} onRouteChanged={onRouteChanged} />
-        <SidePanel trip={trip} setTrip={setTrip} legs={legs} />
+        <MapEmbed waypoints={trip?.waypoints} onRouteChanged={onRouteChanged} />
+        {!isTripLoading && <SidePanel trip={trip} setTrip={setTrip} legs={legs} />}
       </Box>
     </>
   );

--- a/src/components/TripPage/TripPage.js
+++ b/src/components/TripPage/TripPage.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import MapEmbed from '../MapEmbed/MapEmbed';
 import Header from '../Header/Header';
 import { useParams } from 'react-router-dom';
@@ -11,11 +11,13 @@ export default function TripPage() {
   const { trip, setTrip } = useTrip(id);
   const [legs, setLegs] = useState(null);
 
+  const onRouteChanged = useCallback((route) => setLegs(route.legs), [setLegs]);
+
   return (
     <>
       <Header />
       <Box pos="relative">
-        <MapEmbed {...trip} setLegs={setLegs} />
+        <MapEmbed waypoints={trip.waypoints} onRouteChanged={onRouteChanged} />
         <SidePanel trip={trip} setTrip={setTrip} legs={legs} />
       </Box>
     </>

--- a/src/components/WaypointList/WaypointList.js
+++ b/src/components/WaypointList/WaypointList.js
@@ -4,15 +4,15 @@ import { updateWaypoints } from '../../services/trips';
 import { useState } from 'react';
 import { Box, Flex, Text } from '@chakra-ui/react';
 
-export default function WaypointList({ waypoints, setTrip, trip, legs }) {
+export default function WaypointList({ trip, setTrip, legs }) {
 
   const [totalDistance, setTotalDistance] = useState('');
   const [totalTime, setTotalTime] = useState('');
   const [prevLegs, setPrevLegs] = useState([]);
   const [randomKey, setRandomKey] = useState(0);
 
-  const positionedWaypoints = waypoints.map((waypoint, i) => ({ ...waypoint, position: i }));
-  
+  const positionedWaypoints = trip.waypoints.map((waypoint, i) => ({ ...waypoint, position: i }));
+
   const getTotalDistance = () => {
     const miles = legs.reduce((a, b) => {
       a.push(b.distance.text);
@@ -21,7 +21,7 @@ export default function WaypointList({ waypoints, setTrip, trip, legs }) {
       .map(d => Number(d.split(' ')[0].replace(',', '')))
       .reduce((a, b) => a + b, 0)
       .toString();
-    
+
     let stringifiedMiles = '';
 
     if (!miles.includes('.')) {
@@ -31,7 +31,7 @@ export default function WaypointList({ waypoints, setTrip, trip, legs }) {
     } else {
       const splitMiles = miles.split('.');
       const intMiles = splitMiles[0];
-      const formattedIntMiles = intMiles.length > 3 ? 
+      const formattedIntMiles = intMiles.length > 3 ?
         [intMiles.slice(0, intMiles.length - 3), ',', intMiles.slice(intMiles.length - 3)].join('')
         : intMiles;
       stringifiedMiles = [formattedIntMiles, '.', splitMiles[1]].join('');
@@ -57,7 +57,7 @@ export default function WaypointList({ waypoints, setTrip, trip, legs }) {
 
     hours += Math.floor(minutes / 60);
     minutes %= 60;
-    
+
     return minutes ? `${hours} hrs ${minutes} mins` : `${hours} hrs`;
   };
 
@@ -88,7 +88,7 @@ export default function WaypointList({ waypoints, setTrip, trip, legs }) {
   return (
     <Box w="250px">
       <Draggable onPosChange={onPosChange} key={randomKey}>
-        {waypoints.map((waypoint, i) => (
+        {trip.waypoints.map((waypoint, i) => (
           <Waypoint
             key={waypoint.id}
             {...waypoint} trip={trip}

--- a/src/components/WaypointList/WaypointList.js
+++ b/src/components/WaypointList/WaypointList.js
@@ -5,13 +5,10 @@ import { useState } from 'react';
 import { Box, Flex, Text } from '@chakra-ui/react';
 
 export default function WaypointList({ trip, setTrip, legs }) {
-
   const [totalDistance, setTotalDistance] = useState('');
   const [totalTime, setTotalTime] = useState('');
   const [prevLegs, setPrevLegs] = useState([]);
   const [randomKey, setRandomKey] = useState(0);
-
-  const positionedWaypoints = trip.waypoints.map((waypoint, i) => ({ ...waypoint, position: i }));
 
   const getTotalDistance = () => {
     const miles = legs.reduce((a, b) => {
@@ -69,9 +66,9 @@ export default function WaypointList({ trip, setTrip, legs }) {
   }
 
   const onPosChange = async (currentPos, newPos) => {
-    positionedWaypoints[currentPos].position = newPos;
+    trip.waypoints[currentPos].position = newPos;
     if (newPos !== currentPos) {
-      positionedWaypoints.forEach((waypoint, i) => {
+      trip.waypoints.forEach((waypoint, i) => {
         if (newPos > currentPos && i > currentPos && i <= newPos) {
           waypoint.position--;
         }
@@ -79,8 +76,8 @@ export default function WaypointList({ trip, setTrip, legs }) {
           waypoint.position++;
         }
       });
-      positionedWaypoints.sort((a, b) => a.position - b.position);
-      const updatedWaypoints = await updateWaypoints(positionedWaypoints);
+      trip.waypoints.sort((a, b) => a.position - b.position);
+      const updatedWaypoints = await updateWaypoints(trip.waypoints);
       setTrip({ ...trip, waypoints: updatedWaypoints });
     }
   };

--- a/src/components/WaypointList/WaypointList.js
+++ b/src/components/WaypointList/WaypointList.js
@@ -66,20 +66,14 @@ export default function WaypointList({ trip, setTrip, legs }) {
   }
 
   const onPosChange = async (currentPos, newPos) => {
-    trip.waypoints[currentPos].position = newPos;
-    if (newPos !== currentPos) {
-      trip.waypoints.forEach((waypoint, i) => {
-        if (newPos > currentPos && i > currentPos && i <= newPos) {
-          waypoint.position--;
-        }
-        if (currentPos > newPos && i < currentPos && i >= newPos) {
-          waypoint.position++;
-        }
-      });
-      trip.waypoints.sort((a, b) => a.position - b.position);
-      const updatedWaypoints = await updateWaypoints(trip.waypoints);
-      setTrip({ ...trip, waypoints: updatedWaypoints });
-    }
+    if (currentPos === newPos) return;
+
+    const waypoints = [...trip.waypoints];
+    const [shiftedWaypoint] = waypoints.splice(currentPos, 1);
+    waypoints.splice(newPos, 0, shiftedWaypoint);
+
+    const updatedWaypoints = await updateWaypoints(waypoints);
+    setTrip({ ...trip, waypoints: updatedWaypoints });
   };
 
   return (

--- a/src/hooks/useTrip.js
+++ b/src/hooks/useTrip.js
@@ -2,12 +2,16 @@ import { useEffect, useState } from 'react';
 import { getTripById } from '../services/trips';
 
 export function useTrip(id) {
-  const [trip, setTrip] = useState({});
+  const [trip, setTrip] = useState();
+  const [loading, setLoading] = useState(true);
+
   useEffect(() => {
     const fetchTrip = async () => {
       try {
+        setLoading(true);
         const data = await getTripById(id);
         setTrip(data);
+        setLoading(false);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error(e);
@@ -16,5 +20,5 @@ export function useTrip(id) {
     fetchTrip();
   }, [id]);
 
-  return { trip, setTrip };
+  return { trip, setTrip, loading };
 }


### PR DESCRIPTION
I'm sorry about the all-over nature of this PR. I started off trying to simplify some logic on the edit trip page, and things got away from me. The changes in this patch are:

- MapEmbed triggers directions request imperatively and provides a callback for the whole route. This could still be improved by providing the entire response object, so we can present errors when we can't find directions for a route.
- MapEmbed gives the map an initial zoom and center so we can see the map even if the direction request fails or is taking a long time.
- Makes the loading state of the useTrip hook more explicit. (We could still use a loading component.)
- Simplifies waypoint reordering in WaypointList.
- Adds a reusable PlaceInput component that autocompletes places and uses it on the edit trip page.